### PR TITLE
Added an error screen

### DIFF
--- a/src/loader.h
+++ b/src/loader.h
@@ -32,6 +32,7 @@ void emu_settings_kconf_render();
 int set_kconf_key(char* key_to_change);
 void set_kconf_key_render(char* key_to_change);
 char* emu_settings_getkey(int hexval);
+void error_handler(char * errorString);
 
 
 char kb_text[256];


### PR DESCRIPTION
Instead of calling OSFatal to handle errors, I've implemented a
function to handle errors that doesn't freeze the console.

I believe that this is more convenient for users, as they don't have to go through the process of rebooting their console in the event of an error.